### PR TITLE
making nav links 'pop out' and adding some spacing

### DIFF
--- a/web/themes/default/css/default.css
+++ b/web/themes/default/css/default.css
@@ -138,6 +138,10 @@ form .file{
 	box-shadow: 0 0 46px 0 rgba(0,0,0,2.5);
 	background: #fff;
 }
+#header a {
+	color: #fefefe; 
+	padding-right: 6px; 
+}
 @media (min-width: 1200px){
 	.container {
 		width: 1000px;

--- a/web/themes/default/templates/layouts/default.html
+++ b/web/themes/default/templates/layouts/default.html
@@ -23,8 +23,8 @@
 	<body>
 		<section id="main" class="container-fluid" role="main">
 			<header id="header" role="header" class="container">
-				<a href="https://github.com/ijoey/devchitchat/issues" title="devchitchat issues" class="fa">Issues</a>
-				<a href="https://github.com/ijoey/devchitchat" title="devchitchat repo" class="fa fa-github">Code</a>
+				<a href="https://github.com/ijoey/devchitchat/issues" title="devchitchat issues" class="fa" target="_blank">Issues</a>
+				<a href="https://github.com/ijoey/devchitchat" title="devchitchat repo" class="fa fa-github" target="_blank">Code</a>
 				<a href="/" title="devchitchat index"><%= config.site.title %></a>
 				<% if(request.isAuthenticated()){%>
 				<a href="/welcome" title="Welcome room">Welcome</a>


### PR DESCRIPTION
This has bugged me for awhile since I like to view DCC in a big window at home.  This PR makes the links at the top stand out on the wood background and puts a little space in between them.  Also made the issues and code links open in a new tab so you keep the chat window when you go to the issue tracker.